### PR TITLE
feat: improve truncation and add ignore dir option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 micelia
-
 *.o
+.idea

--- a/README.adoc
+++ b/README.adoc
@@ -31,17 +31,11 @@ micelia [OPTIONS] PATH
 
 - Count lines of code in a directory, excluding the "test" and "vendor" folders:
 
-  [source,sh]
-  ----
   micelia -i test -i vendor /path/to/directory
-  ----
 
 - Count lines of code in a directory without ignoring any folders:
 
-  [source,sh]
-  ----
   micelia /path/to/directory
-  -----
 
 === ⚠️ Note
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,52 @@
 == 🍄 micelia
 
-a naive SLOC counter
+A naive SLOC (source lines of code) counter.
 
-=== 📑 instructions
+=== 📑 Instructions
+
+==== Installation
+
 [source,sh]
 ----
-sudo make install clean
+sudo make install
+----
+==== Uninstallation
+[source,sh]
+----
+sudo make clean
 ----
 
+==== Usage
 
+[source,sh]
+----
+micelia [OPTIONS] PATH
+----
+
+===== Options
+
+- `-i` or `--ignore`:: Ignore specified directories. You can add multiple directories to ignore by using this option multiple times.
+
+===== Examples
+
+- Count lines of code in a directory, excluding the "test" and "vendor" folders:
+
+  [source,sh]
+  ----
+  micelia -i test -i vendor /path/to/directory
+  ----
+
+- Count lines of code in a directory without ignoring any folders:
+
+  [source,sh]
+  ----
+  micelia /path/to/directory
+  -----
+
+=== ⚠️ Note
+
+This SLOC counter is a simple implementation and may not handle all edge cases. Please report any issues you encounter.
+
+=== 📄 License
+
+Provide information about the licensing of the code, if applicable.

--- a/README.adoc
+++ b/README.adoc
@@ -1,46 +1,55 @@
 == 🍄 micelia
 
-A naive SLOC (source lines of code) counter.
+a naive SLOC (source lines of code) counter.
 
-=== 📑 Instructions
+=== 📑 instructions
 
-==== Installation
+==== installation
 
 [source,sh]
 ----
 sudo make install
 ----
-==== Uninstallation
+==== uninstallation
 [source,sh]
 ----
 sudo make clean
 ----
 
-==== Usage
+==== usage
 
 [source,sh]
 ----
 micelia [OPTIONS] PATH
 ----
 
-===== Options
+===== options
 
-- `-i` or `--ignore`:: Ignore specified directories. You can add multiple directories to ignore by using this option multiple times.
+- `-i` or `--ignore`:: ignore specified directories. you can add multiple directories to ignore by using this option multiple times.
 
-===== Examples
+===== examples
 
-- Count lines of code in a directory, excluding the "test" and "vendor" folders:
+- count lines of code in a directory, excluding the "test" and "vendor" folders:
 
   micelia -i test -i vendor /path/to/directory
 
-- Count lines of code in a directory without ignoring any folders:
+- count lines of code in a directory without ignoring any folders:
 
   micelia /path/to/directory
 
-=== ⚠️ Note
+=== ⭐ contributors
+a heartfelt thank you goes out to all those who have contributed to 🍄 micelia. whether you've helped with code, documentation, design, or anything in between, your contributions are valued and appreciated.
 
-This SLOC counter is a simple implementation and may not handle all edge cases. Please report any issues you encounter.
+_made a contribution? add yourself below!
 
-=== 📄 License
+    - *https://github.com/letrad[letrad]* - added; ignore command, dynamic strings.
 
-Provide information about the licensing of the code, if applicable.
+
+=== ⚠️ note
+
+this SLOC counter is a simple implementation and may not handle all edge cases. please report any problems you have as https://github.com/drainpixie/micelia/issues[issues].
+
+
+=== 📄 license
+
+this project is licensed under the gnu lesser general public license v3.0


### PR DESCRIPTION
This PR addresses two main issues in the code:

1. **Fixing File Name Truncation**: The previous fixed width for the file path caused truncation in the output for any file paths longer than the specified length. This PR adjusts the logic to handle longer file names without truncation.

2. **Adding Directory Ignore Flag**: Introduced a command-line flag that allows specific directories to be ignored during the file parsing process. This provides more control over the directories that are processed, enabling a more targeted analysis.

### Changes:
- Modified the string formatting to handle file paths of varying lengths, ensuring no truncation occurs.
- Implemented a new command-line flag to specify directories to ignore, enhancing flexibility.

### Testing:
The changes have been tested with various file and directory structures to ensure that the file names are displayed correctly and the ignore flag functions as intended.

Please review the changes and let me know if any modifications or additional information are required.

A Drunken Foe,
Letradical.